### PR TITLE
fix: Minor changes to improve user experience

### DIFF
--- a/components/forms/HomeSearch.tsx
+++ b/components/forms/HomeSearch.tsx
@@ -52,7 +52,7 @@ function HomeSearch(props: {
         <input
           type="text"
           className="bg-white shadow-md outline-none p-3 w-full"
-          placeholder="Search posts"
+          placeholder="Search other's posts"
           onChange={(e) => setSearchStr(e.target.value)}
           onKeyDown={(e) => {
             if (e.key == "Enter") handleSearch();

--- a/components/forms/HomeSearch.tsx
+++ b/components/forms/HomeSearch.tsx
@@ -47,12 +47,12 @@ function HomeSearch(props: {
 
   return (
     <div className="bg-[#f2f2f2] px-10 pt-[60px] border-b-2 border-b-neutral-200 pb-5">
-      <p className="pt-5 text-2xl">Find the best restaurants and food spots.</p>
+      <p className="pt-5 text-2xl">Find the best restaurants and food spots</p>
       <div className="flex w-full xl:w-[50%] rounded-xl overflow-hidden mt-2">
         <input
           type="text"
           className="bg-white shadow-md outline-none p-3 w-full"
-          placeholder="Search post, restaurant, user..."
+          placeholder="Search posts"
           onChange={(e) => setSearchStr(e.target.value)}
           onKeyDown={(e) => {
             if (e.key == "Enter") handleSearch();

--- a/components/forms/PostSearch.tsx
+++ b/components/forms/PostSearch.tsx
@@ -57,12 +57,12 @@ function PostSearch(props: {
 
   return (
     <div className="bg-[#f2f2f2] px-10 pt-15 border-b-2 border-b-neutral-200 pb-5">
-      <p className="pt-5 text-2xl">Find posts or restaurants.</p>
+      <p className="pt-5 text-2xl">Find posts or restaurants</p>
       <div className="flex w-full rounded-xl overflow-hidden mt-2">
         <input
           type="text"
           className="bg-white shadow-md outline-none p-3 w-full "
-          placeholder="Search posts or resturants..."
+          placeholder="Search posts"
           onChange={(e) => setSearchStr(e.target.value)}
           onKeyDown={(e) => {
             if (e.key == "Enter") handleSearch();

--- a/components/modals/Review/CreateReviewModal.tsx
+++ b/components/modals/Review/CreateReviewModal.tsx
@@ -28,7 +28,7 @@ function CreateReviewModal(props: {
   const [tags, setTags] = useState<string[]>([]);
   const [titleInput, setTitleInput] = useState<string>("");
   const [descInput, setDescInput] = useState<string>("");
-  const [ratingInput, setRatingInput] = useState<number>(2.5);
+  const [ratingInput, setRatingInput] = useState<number>(0);
   const [budgetInput, setBudgetInput] = useState<number>(2);
   const [imagesInput, setImagesInput] = useState<File[]>([]);
   const [submitting, setSubmitting] = useState(false);

--- a/components/modals/SelectRest/SRMMap.tsx
+++ b/components/modals/SelectRest/SRMMap.tsx
@@ -103,7 +103,7 @@ function SRMMap(props: { onMarkerClick: (rest: Restaurant) => Promise<void> }) {
             <input
               type="text"
               className="bg-white shadow-md outline-none px-3 py-2 w-full"
-              placeholder="Enter restaurant..."
+              placeholder="Search restaurant"
               onChange={(e) => setSearchStr(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key == "Enter") handleSearch();

--- a/components/rest/AddToCollectionModal.tsx
+++ b/components/rest/AddToCollectionModal.tsx
@@ -100,9 +100,9 @@ export default function AddToCollectionModal({
             href="/collections"
             className="flex flex-col items-center gap-1 mt-4 mb-4"
           >
-            <p className="text-m text-gray-400">You have no collections yet.</p>
+            <p className="text-m text-gray-400">You have no collections yet</p>
             <p className="text-m text-gray-400">
-              Click here to go to the Collections page.
+              Click here to go to the Collections page
             </p>
           </Link>
         ) : (


### PR DESCRIPTION
[Improve post-lookup search bar handler](https://github.com/EvanA4/Savorly/issues/46)

Chose to change the search bar to only say Search Posts since it was confusing to see "Search for restaurants and posts" even though you can only Ctrl+F for posts. It's also way too demanding of a task to try and implement a restaurant lookup for such a short amount of time. 